### PR TITLE
refactor(file): PostgreSQL smallint 布尔列全链路迁移 + json 列 TypeHandler

### DIFF
--- a/fs-framework/fs-orm/src/main/java/com/xddcodec/fs/framework/orm/handler/JsonStringTypeHandler.java
+++ b/fs-framework/fs-orm/src/main/java/com/xddcodec/fs/framework/orm/handler/JsonStringTypeHandler.java
@@ -1,0 +1,54 @@
+package com.xddcodec.fs.framework.orm.handler;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedJdbcTypes;
+import org.apache.ibatis.type.MappedTypes;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * JSON 列 String 互转 TypeHandler。
+ *
+ * <p>适配 PostgreSQL json / MySQL json 列:写入时通过 {@link Types#OTHER} 让驱动按列元数据类型识别,
+ * 避免 PostgreSQL 因不存在 varchar → json 隐式转换而抛
+ * <em>"字段 ... 的类型为 json, 但表达式的类型为 character varying"</em>。</p>
+ *
+ * <p>使用方式:在实体字段上显式声明
+ * <pre>{@code
+ * @Column(jdbcType = JdbcType.OTHER, typeHandler = JsonStringTypeHandler.class)
+ * private String configScheme;
+ * }</pre>
+ * 读端直接走 {@link ResultSet#getString},驱动会按列类型反序列化为 JSON 文本。</p>
+ *
+ * @author xddcode
+ */
+@MappedTypes(String.class)
+@MappedJdbcTypes(value = JdbcType.OTHER, includeNullJdbcType = true)
+public class JsonStringTypeHandler extends BaseTypeHandler<String> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType) throws SQLException {
+        // Types.OTHER + String -> PostgreSQL/MySQL 驱动按列元数据类型(json)解析并校验
+        ps.setObject(i, parameter, Types.OTHER);
+    }
+
+    @Override
+    public String getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return rs.getString(columnName);
+    }
+
+    @Override
+    public String getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return rs.getString(columnIndex);
+    }
+
+    @Override
+    public String getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return cs.getString(columnIndex);
+    }
+}

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/FileInfo.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/FileInfo.java
@@ -59,9 +59,9 @@ public class FileInfo implements Serializable {
     private String mimeType;
 
     /**
-     * 是否目录
+     * 是否目录（0-否 1-是，对应 smallint 列）
      */
-    private Boolean isDir;
+    private Integer isDir;
 
     /**
      * 父目录ID
@@ -104,9 +104,9 @@ public class FileInfo implements Serializable {
     private LocalDateTime lastAccessTime;
 
     /**
-     * 软删除标记，回收站标识0：未删除 1：已删除
+     * 软删除标记，回收站标识 0：未删除 1：已删除（对应 smallint 列）
      */
-    private Boolean isDeleted;
+    private Integer isDeleted;
 
     /**
      * 删除时间

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/qry/FileQry.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/qry/FileQry.java
@@ -24,6 +24,6 @@ public class FileQry extends PageQuery {
     @Schema(description = "最近使用", example = "true")
     private Boolean isRecents;
 
-    @Schema(description = "是否目录", example = "true")
-    private Boolean isDir;
+    @Schema(description = "是否目录", example = "1")
+    private Integer isDir;
 }

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/vo/FileDetailVO.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/vo/FileDetailVO.java
@@ -44,7 +44,7 @@ public class FileDetailVO implements Serializable {
     /**
      * 是否文件夹
      */
-    private Boolean isDir;
+    private Integer isDir;
 
     /**
      * 缩略图URL

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/vo/FileRecycleVO.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/vo/FileRecycleVO.java
@@ -40,7 +40,7 @@ public class FileRecycleVO implements Serializable {
     /**
      * 是否目录
      */
-    private Boolean isDir;
+    private Integer isDir;
 
     /**
      * 上传时间

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/vo/FileVO.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/domain/vo/FileVO.java
@@ -55,7 +55,7 @@ public class FileVO implements Serializable {
     /**
      * 是否目录
      */
-    private Boolean isDir;
+    private Integer isDir;
 
     /**
      * 父目录ID

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/schedule/RecycleBinCleanupTask.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/schedule/RecycleBinCleanupTask.java
@@ -5,6 +5,7 @@ import com.mybatisflex.core.query.QueryWrapper;
 import com.xddcodec.fs.file.domain.FileInfo;
 import com.xddcodec.fs.file.service.FileInfoService;
 import com.xddcodec.fs.file.service.FileRecycleService;
+import com.xddcodec.fs.framework.common.constant.CommonConstant;
 import com.xddcodec.fs.framework.common.context.WorkspaceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -78,7 +79,7 @@ public class RecycleBinCleanupTask {
 
     private List<FileInfo> findExpiredFiles(LocalDateTime expireTime) {
         QueryWrapper queryWrapper = QueryWrapper.create()
-                .where(FILE_INFO.IS_DELETED.eq(true))
+                .where(FILE_INFO.IS_DELETED.eq(CommonConstant.Y))
                 .and(FILE_INFO.DELETED_TIME.lt(expireTime))
                 .orderBy(FILE_INFO.DELETED_TIME.asc());
         return fileInfoService.list(queryWrapper);

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/FileInfoService.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/FileInfoService.java
@@ -69,7 +69,7 @@ public interface FileInfoService extends IService<FileInfo> {
      * @return 唯一的文件名
      */
     String generateUniqueName(String workspaceId, String parentId,
-                              String desiredName, Boolean isDir,
+                              String desiredName, Integer isDir,
                               String excludeFileId, String storagePlatformSettingId);
 
     /**

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileHomeServiceImpl.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileHomeServiceImpl.java
@@ -10,6 +10,7 @@ import com.xddcodec.fs.file.domain.vo.FileHomeVO;
 import com.xddcodec.fs.file.domain.vo.FileVO;
 import com.xddcodec.fs.file.service.FileHomeService;
 import com.xddcodec.fs.file.service.FileInfoService;
+import com.xddcodec.fs.framework.common.constant.CommonConstant;
 import com.xddcodec.fs.framework.common.context.WorkspaceContext;
 import com.xddcodec.fs.framework.common.domain.PageResult;
 import com.xddcodec.fs.storage.plugin.core.context.StoragePlatformContextHolder;
@@ -65,8 +66,8 @@ public class FileHomeServiceImpl implements FileHomeService {
                 .select(FILE_INFO.UPLOAD_TIME, FILE_INFO.SIZE)
                 .where(FILE_INFO.WORKSPACE_ID.eq(workspaceId))
                 .and(FILE_INFO.STORAGE_PLATFORM_SETTING_ID.eq(storageId))
-                .and(FILE_INFO.IS_DIR.eq(false))
-                .and(FILE_INFO.IS_DELETED.eq(false))
+                .and(FILE_INFO.IS_DIR.eq(CommonConstant.N))
+                .and(FILE_INFO.IS_DELETED.eq(CommonConstant.N))
                 .and(FILE_INFO.UPLOAD_TIME.between(startTime, endTime));
 
         List<FileInfo> files = fileInfoService.list(queryWrapper);

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileInfoServiceImpl.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileInfoServiceImpl.java
@@ -17,6 +17,7 @@ import com.xddcodec.fs.file.domain.vo.FileDetailVO;
 import com.xddcodec.fs.file.domain.vo.FileVO;
 import com.xddcodec.fs.file.mapper.FileInfoMapper;
 import com.xddcodec.fs.file.service.FileInfoService;
+import com.xddcodec.fs.framework.common.constant.CommonConstant;
 import com.xddcodec.fs.framework.common.domain.PageResult;
 import com.xddcodec.fs.framework.common.enums.FileTypeEnum;
 import com.xddcodec.fs.framework.common.context.WorkspaceContext;
@@ -67,10 +68,10 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         if (fileInfo == null) {
             throw new StorageOperationException(I18nUtils.getMessage("file.not.exist", new Object[]{fileId}));
         }
-        if (fileInfo.getIsDir()) {
+        if (CommonConstant.Y.equals(fileInfo.getIsDir())) {
             throw new StorageOperationException(I18nUtils.getMessage("file.cannot.download.dir", new Object[]{fileId}));
         }
-        if (fileInfo.getIsDeleted()) {
+        if (CommonConstant.Y.equals(fileInfo.getIsDeleted())) {
             throw new StorageOperationException(I18nUtils.getMessage("file.deleted", new Object[]{fileId}));
         }
 
@@ -91,10 +92,10 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         if (fileInfo == null) {
             throw new StorageOperationException(I18nUtils.getMessage("file.not.exist", new Object[]{fileId}));
         }
-        if (fileInfo.getIsDir()) {
+        if (CommonConstant.Y.equals(fileInfo.getIsDir())) {
             throw new StorageOperationException(I18nUtils.getMessage("file.dir.no.url", new Object[]{fileId}));
         }
-        if (fileInfo.getIsDeleted()) {
+        if (CommonConstant.Y.equals(fileInfo.getIsDeleted())) {
             throw new StorageOperationException(I18nUtils.getMessage("file.deleted", new Object[]{fileId}));
         }
         IStorageOperationService storageService = storageServiceFacade.getStorageService(fileInfo.getStoragePlatformSettingId());
@@ -121,11 +122,11 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         LocalDateTime now = LocalDateTime.now();
 
         for (FileInfo fileInfo : fileInfoList) {
-            if (!fileInfo.getIsDeleted()) {
+            if (!CommonConstant.Y.equals(fileInfo.getIsDeleted())) {
                 toDeleteList.add(fileInfo);
 
                 // 如果是文件夹，递归获取所有子文件和子文件夹
-                if (fileInfo.getIsDir()) {
+                if (CommonConstant.Y.equals(fileInfo.getIsDir())) {
                     List<FileInfo> children = getAllChildrenRecursively(fileInfo.getId(), false);
                     toDeleteList.addAll(children);
                 }
@@ -138,7 +139,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
 
         // 批量标记为删除
         toDeleteList.forEach(fileInfo -> {
-            fileInfo.setIsDeleted(true);
+            fileInfo.setIsDeleted(CommonConstant.Y);
             fileInfo.setDeletedTime(now);
         });
 
@@ -161,7 +162,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
                 .where(FILE_INFO.PARENT_ID.eq(parentId));
 
         if (!includeDeleted) {
-            query.and(FILE_INFO.IS_DELETED.eq(false));
+            query.and(FILE_INFO.IS_DELETED.eq(CommonConstant.N));
         }
 
         List<FileInfo> directChildren = list(query);
@@ -170,7 +171,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
             allChildren.add(child);
 
             // 如果是文件夹，递归查询
-            if (child.getIsDir()) {
+            if (CommonConstant.Y.equals(child.getIsDir())) {
                 allChildren.addAll(getAllChildrenRecursively(child.getId(), includeDeleted));
             }
         }
@@ -191,7 +192,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
                 workspaceId,
                 cmd.getParentId(),
                 baseName,
-                true,
+                CommonConstant.Y,
                 null,
                 platformConfigId
         );
@@ -199,7 +200,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         dirInfo.setId(folderId);
         dirInfo.setOriginalName(finalName);
         dirInfo.setDisplayName(finalName);
-        dirInfo.setIsDir(true);
+        dirInfo.setIsDir(CommonConstant.Y);
         dirInfo.setParentId(cmd.getParentId());
         dirInfo.setWorkspaceId(workspaceId);
         dirInfo.setUserId(userId);
@@ -207,7 +208,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         LocalDateTime now = LocalDateTime.now();
         dirInfo.setUploadTime(now);
         dirInfo.setUpdateTime(now);
-        dirInfo.setIsDeleted(false);
+        dirInfo.setIsDeleted(CommonConstant.N);
         save(dirInfo);
         return dirInfo;
     }
@@ -250,7 +251,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
 
         if (targetDirId != null) {
             FileInfo dirInfo = getById(targetDirId);
-            if (dirInfo == null || !dirInfo.getIsDir()) {
+            if (dirInfo == null || !CommonConstant.Y.equals(dirInfo.getIsDir())) {
                 throw new BusinessException(I18nUtils.getMessage("file.target.dir.invalid"));
             }
         }
@@ -263,7 +264,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
                 continue;
             }
 
-            if (targetDirId != null && fileInfo.getIsDir()) {
+            if (targetDirId != null && CommonConstant.Y.equals(fileInfo.getIsDir())) {
                 if (fileInfo.getId().equals(targetDirId) || isSubDirectory(fileInfo.getId(), targetDirId)) {
                     throw new BusinessException(I18nUtils.getMessage("file.cannot.move.to.self", 
                             new Object[]{fileInfo.getDisplayName()}));
@@ -318,12 +319,12 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
      */
     @Override
     public String generateUniqueName(String workspaceId, String parentId,
-                                     String desiredName, Boolean isDir,
+                                     String desiredName, Integer isDir,
                                      String excludeFileId, String storagePlatformSettingId) {
 
         String nameWithoutExt = desiredName;
         String extension = "";
-        if (!isDir && desiredName.contains(".")) {
+        if (!CommonConstant.Y.equals(isDir) && desiredName.contains(".")) {
             int lastDotIndex = desiredName.lastIndexOf(".");
             nameWithoutExt = desiredName.substring(0, lastDotIndex);
             extension = desiredName.substring(lastDotIndex);
@@ -355,13 +356,13 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
      * 构建查询同级目录下同类型文件的条件
      */
     private QueryWrapper buildSameLevelQuery(String workspaceId, String parentId,
-                                             String baseName, Boolean isDir,
+                                             String baseName, Integer isDir,
                                              String excludeFileId, String storagePlatformSettingId) {
         QueryWrapper query = new QueryWrapper();
 
         query.where(FILE_INFO.WORKSPACE_ID.eq(workspaceId))
                 .and(FILE_INFO.IS_DIR.eq(isDir))
-                .and(FILE_INFO.IS_DELETED.eq(false));
+                .and(FILE_INFO.IS_DELETED.eq(CommonConstant.N));
 
         if (StrUtil.isBlank(parentId)) {
             query.and(FILE_INFO.PARENT_ID.isNull());
@@ -394,13 +395,13 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
      */
     private Set<Integer> extractUsedSuffixes(List<FileInfo> existingFiles,
                                              String nameWithoutExt,
-                                             Boolean isDir) {
+                                             Integer isDir) {
         return existingFiles.stream()
                 .map(f -> {
                     String displayName = f.getDisplayName();
 
                     // 移除扩展名（如果是文件）
-                    if (!isDir && displayName.contains(".")) {
+                    if (!CommonConstant.Y.equals(isDir) && displayName.contains(".")) {
                         int lastDotIndex = displayName.lastIndexOf(".");
                         displayName = displayName.substring(0, lastDotIndex);
                     }
@@ -434,8 +435,8 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
      * @return 完整的文件名
      */
     private String buildNameWithSuffix(String nameWithoutExt, int suffixNum,
-                                       String extension, Boolean isDir) {
-        if (isDir) {
+                                       String extension, Integer isDir) {
+        if (CommonConstant.Y.equals(isDir)) {
             // 文件夹：baseName(1)
             return nameWithoutExt + "(" + suffixNum + ")";
         } else {
@@ -490,7 +491,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
                 .on(FILE_INFO.ID.eq(FILE_USER_FAVORITES.FILE_ID)
                         .and(FILE_USER_FAVORITES.USER_ID.eq(userId)))
                 .where(FILE_INFO.WORKSPACE_ID.eq(workspaceId))
-                .and(FILE_INFO.IS_DELETED.eq(false));
+                .and(FILE_INFO.IS_DELETED.eq(CommonConstant.N));
         // 存储平台过滤
         if (StringUtils.isEmpty(storagePlatformSettingId)) {
             wrapper.and(FILE_INFO.STORAGE_PLATFORM_SETTING_ID.isNull());
@@ -499,7 +500,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         }
         // 最近使用视图 (Recents)
         if (Boolean.TRUE.equals(qry.getIsRecents())) {
-            wrapper.and(FILE_INFO.IS_DIR.eq(false))
+            wrapper.and(FILE_INFO.IS_DIR.eq(CommonConstant.N))
                     .orderBy(FILE_INFO.LAST_ACCESS_TIME.desc());
             // 最近使用通常不需要分页，只需要前 N 条，或者也可以直接分页查询第一页
             pageParam.setPageSize(20);
@@ -510,14 +511,14 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
             }
 
             // 目录/文件视图过滤
-            if (Boolean.TRUE.equals(qry.getIsDir())) {
-                wrapper.and(FILE_INFO.IS_DIR.eq(true));
+            if (CommonConstant.Y.equals(qry.getIsDir())) {
+                wrapper.and(FILE_INFO.IS_DIR.eq(CommonConstant.Y));
             }
 
             // 父目录逻辑：判断是否是特殊筛选视图
             boolean isTypeFilter = StrUtil.isNotBlank(qry.getFileType());
             boolean isFavoriteView = Boolean.TRUE.equals(qry.getIsFavorite()) && qry.getParentId() == null;
-            boolean isDirFilter = Boolean.TRUE.equals(qry.getIsDir()) && qry.getParentId() == null;
+            boolean isDirFilter = CommonConstant.Y.equals(qry.getIsDir()) && qry.getParentId() == null;
 
             if (!isTypeFilter && !isFavoriteView && !isDirFilter) {
                 if (qry.getParentId() == null) {
@@ -583,8 +584,8 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         List<FileInfo> fileInfoList = this.list(new QueryWrapper()
                 .where(FILE_INFO.WORKSPACE_ID.eq(workspaceId)
                         .and(FILE_INFO.STORAGE_PLATFORM_SETTING_ID.eq(storagePlatformSettingId))
-                        .and(FILE_INFO.IS_DELETED.eq(false))
-                        .and(FILE_INFO.IS_DIR.eq(false))
+                        .and(FILE_INFO.IS_DELETED.eq(CommonConstant.N))
+                        .and(FILE_INFO.IS_DIR.eq(CommonConstant.N))
                 ));
 
         // 统计总大小
@@ -602,7 +603,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
             throw new BusinessException(I18nUtils.getMessage("file.not.found"));
         }
         FileDetailVO vo = converter.convert(fileInfo, FileDetailVO.class);
-        if (vo.getIsDir()) {
+        if (CommonConstant.Y.equals(vo.getIsDir())) {
             Map<String, Long> stats = new HashMap<>();
             stats.put("size", 0L);
             stats.getOrDefault("fileCount", 0L);
@@ -632,14 +633,14 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
                 .where(FILE_INFO.PARENT_ID.eq(parentId))
                 .and(FILE_INFO.WORKSPACE_ID.eq(workspaceId))
                 .and(FILE_INFO.STORAGE_PLATFORM_SETTING_ID.eq(storagePlatformSettingId))
-                .and(FILE_INFO.IS_DELETED.eq(false)));
+                .and(FILE_INFO.IS_DELETED.eq(CommonConstant.N)));
 
         if (CollUtil.isEmpty(children)) {
             return;
         }
 
         for (FileInfo child : children) {
-            if (child.getIsDir()) {
+            if (CommonConstant.Y.equals(child.getIsDir())) {
                 // 统计文件夹个数并向下递归
                 stats.put("folderCount", stats.get("folderCount") + 1);
                 recursiveAccumulate(child.getId(), stats);
@@ -659,8 +660,8 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         QueryWrapper wrapper = new QueryWrapper();
         wrapper.where(FILE_INFO.WORKSPACE_ID.eq(workspaceId)
                 .and(FILE_INFO.STORAGE_PLATFORM_SETTING_ID.eq(storagePlatformSettingId))
-                .and(FILE_INFO.IS_DELETED.eq(false))
-                .and(FILE_INFO.IS_DIR.eq(true))
+                .and(FILE_INFO.IS_DELETED.eq(CommonConstant.N))
+                .and(FILE_INFO.IS_DIR.eq(CommonConstant.Y))
         );
 
         if (StrUtil.isNotBlank(parentId)) {
@@ -713,7 +714,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
             // OTHER 分类：匹配 OTHER 分类的已知后缀 + 所有未知后缀
             List<String> allOtherKnownSuffixes = FileTypeEnum.getAllKnownSuffixesExcluding(FileTypeEnum.FileCategory.OTHER);
 
-            wrapper.and(FILE_INFO.IS_DIR.eq(false))
+            wrapper.and(FILE_INFO.IS_DIR.eq(CommonConstant.N))
                     .and(
                             FILE_INFO.SUFFIX.in(categorySuffixes) // zip、rar 等
                                     .or(FILE_INFO.SUFFIX.notIn(allOtherKnownSuffixes)) // 真正的未知类型
@@ -722,7 +723,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         } else {
             // 常规分类：直接匹配后缀
             if (!categorySuffixes.isEmpty()) {
-                wrapper.and(FILE_INFO.IS_DIR.eq(false))
+                wrapper.and(FILE_INFO.IS_DIR.eq(CommonConstant.N))
                         .and(FILE_INFO.SUFFIX.in(categorySuffixes));
             }
         }
@@ -735,7 +736,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
         if (fileType.isOther()) {
             // 其他类型：排除所有已知后缀
             List<String> knownSuffixes = FileTypeEnum.getAllKnownSuffixes();
-            wrapper.and(FILE_INFO.IS_DIR.eq(false))
+            wrapper.and(FILE_INFO.IS_DIR.eq(CommonConstant.N))
                     .and(
                             FILE_INFO.SUFFIX.notIn(knownSuffixes)
                                     .or(FILE_INFO.SUFFIX.isNull().or(FILE_INFO.SUFFIX.eq("")))
@@ -744,7 +745,7 @@ public class FileInfoServiceImpl extends ServiceImpl<FileInfoMapper, FileInfo> i
             // 具体类型：直接匹配后缀
             List<String> suffixes = fileType.getSuffixes();
             if (suffixes != null && !suffixes.isEmpty()) {
-                wrapper.and(FILE_INFO.IS_DIR.eq(false))
+                wrapper.and(FILE_INFO.IS_DIR.eq(CommonConstant.N))
                         .and(FILE_INFO.SUFFIX.in(suffixes));
             }
         }

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileRecycleServiceImpl.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileRecycleServiceImpl.java
@@ -13,6 +13,7 @@ import com.xddcodec.fs.file.domain.vo.FileRecycleVO;
 import com.xddcodec.fs.file.service.FileInfoService;
 import com.xddcodec.fs.file.service.FileRecycleService;
 import com.xddcodec.fs.file.service.FileUserFavoritesService;
+import com.xddcodec.fs.framework.common.constant.CommonConstant;
 import com.xddcodec.fs.framework.common.context.WorkspaceContext;
 import com.xddcodec.fs.framework.common.domain.PageResult;
 import com.xddcodec.fs.framework.common.exception.BusinessException;
@@ -69,7 +70,7 @@ public class FileRecycleServiceImpl implements FileRecycleService {
                 .from(t1)
                 .where(t1.WORKSPACE_ID.eq(workspaceId))
                 .and(t1.STORAGE_PLATFORM_SETTING_ID.eq(configId))
-                .and(t1.IS_DELETED.eq(true));
+                .and(t1.IS_DELETED.eq(CommonConstant.Y));
 
         if (StrUtil.isNotBlank(qry.getKeyword())) {
             String keyword = qry.getKeyword().trim();
@@ -86,7 +87,7 @@ public class FileRecycleServiceImpl implements FileRecycleService {
                                                     .select(t2.ID)
                                                     .from(t2)
                                                     .where(t2.ID.eq(t1.PARENT_ID))
-                                                    .and(t2.IS_DELETED.eq(true))
+                                                    .and(t2.IS_DELETED.eq(CommonConstant.Y))
                                     )
                             )
             );
@@ -111,7 +112,7 @@ public class FileRecycleServiceImpl implements FileRecycleService {
         Set<String> allIdsToRestore = collectFileIdsRecursively(
                 fileIds,
                 workspaceId,
-                wrapper -> wrapper.and(FILE_INFO.IS_DELETED.eq(true))
+                wrapper -> wrapper.and(FILE_INFO.IS_DELETED.eq(CommonConstant.Y))
         );
 
         Set<String> parentIdsInRecycle = collectParentIdsInRecycle(fileIds, workspaceId);
@@ -122,7 +123,7 @@ public class FileRecycleServiceImpl implements FileRecycleService {
         }
 
         UpdateChain.of(FileInfo.class)
-                .set(FileInfo::getIsDeleted, false)
+                .set(FileInfo::getIsDeleted, CommonConstant.N)
                 .set(FileInfo::getDeletedTime, null)
                 .where(FILE_INFO.ID.in(allIdsToRestore))
                 .and(FILE_INFO.WORKSPACE_ID.eq(workspaceId))
@@ -153,7 +154,7 @@ public class FileRecycleServiceImpl implements FileRecycleService {
             List<String> deletedParents = fileInfoService.queryChain()
                     .select(FILE_INFO.ID)
                     .where(FILE_INFO.ID.in(pIds))
-                    .and(FILE_INFO.IS_DELETED.eq(true))
+                    .and(FILE_INFO.IS_DELETED.eq(CommonConstant.Y))
                     .listAs(String.class);
 
             if (CollUtil.isEmpty(deletedParents)) break;
@@ -175,7 +176,7 @@ public class FileRecycleServiceImpl implements FileRecycleService {
         Set<String> allFileIds = collectFileIdsRecursively(
                 fileIds,
                 workspaceId,
-                wrapper -> wrapper.and(FILE_INFO.IS_DELETED.eq(true))
+                wrapper -> wrapper.and(FILE_INFO.IS_DELETED.eq(CommonConstant.Y))
         );
         if (CollUtil.isEmpty(allFileIds)) {
             throw new BusinessException(I18nUtils.getMessage("recycle.file.not.found.delete"));
@@ -244,9 +245,9 @@ public class FileRecycleServiceImpl implements FileRecycleService {
                 .from(t1)
                 .where(t1.WORKSPACE_ID.eq(workspaceId))
                 .and(t1.STORAGE_PLATFORM_SETTING_ID.eq(configId))
-                .and(t1.IS_DELETED.eq(true))
+                .and(t1.IS_DELETED.eq(CommonConstant.Y))
                 .and(t1.PARENT_ID.isNull().or(
-                        notExists(QueryWrapper.create().from(t2).where(t2.ID.eq(t1.PARENT_ID)).and(t2.IS_DELETED.eq(true)))
+                        notExists(QueryWrapper.create().from(t2).where(t2.ID.eq(t1.PARENT_ID)).and(t2.IS_DELETED.eq(CommonConstant.Y)))
                 ))
                 .listAs(String.class);
 
@@ -297,7 +298,7 @@ public class FileRecycleServiceImpl implements FileRecycleService {
 
         allFileIds.add(file.getId());
 
-        if (file.getIsDir()) {
+        if (CommonConstant.Y.equals(file.getIsDir())) {
             QueryWrapper wrapper = new QueryWrapper()
                     .where(FILE_INFO.PARENT_ID.eq(file.getId()))
                     .and(FILE_INFO.WORKSPACE_ID.eq(workspaceId));

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileTransferTaskServiceImpl.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileTransferTaskServiceImpl.java
@@ -24,6 +24,7 @@ import com.xddcodec.fs.file.mapper.FileTransferTaskMapper;
 import com.xddcodec.fs.file.service.FileInfoService;
 import com.xddcodec.fs.file.service.FileTransferTaskService;
 import com.xddcodec.fs.file.enums.TransferTaskStatus;
+import com.xddcodec.fs.framework.common.constant.CommonConstant;
 import com.xddcodec.fs.framework.common.context.WorkspaceContext;
 import com.xddcodec.fs.framework.common.exception.BusinessException;
 import com.xddcodec.fs.framework.common.exception.StorageOperationException;
@@ -193,7 +194,7 @@ public class FileTransferTaskServiceImpl extends ServiceImpl<FileTransferTaskMap
                     workspaceId,
                     cmd.getParentId(),
                     cmd.getFileName(),
-                    false,
+                    CommonConstant.N,
                     null,
                     storagePlatformSettingId
             );
@@ -257,7 +258,7 @@ public class FileTransferTaskServiceImpl extends ServiceImpl<FileTransferTaskMap
             String workspaceId = WorkspaceContext.getWorkspaceId();
             queryWrapper.where(FILE_INFO.CONTENT_MD5.eq(cmd.getFileMd5())
                     .and(FILE_INFO.WORKSPACE_ID.eq(workspaceId))
-                    .and(FILE_INFO.IS_DELETED.eq(false)));
+                    .and(FILE_INFO.IS_DELETED.eq(CommonConstant.N)));
             if (StringUtils.isEmpty(storagePlatformSettingId)) {
                 queryWrapper.and(FILE_INFO.STORAGE_PLATFORM_SETTING_ID.isNull());
             } else {
@@ -341,7 +342,7 @@ public class FileTransferTaskServiceImpl extends ServiceImpl<FileTransferTaskMap
                     task.getWorkspaceId(),
                     task.getParentId(),
                     task.getFileName(),
-                    false,
+                    CommonConstant.N,
                     null,
                     storagePlatformSettingId
             );
@@ -353,7 +354,7 @@ public class FileTransferTaskServiceImpl extends ServiceImpl<FileTransferTaskMap
             newFileInfo.setSuffix(task.getSuffix());
             newFileInfo.setSize(task.getFileSize());
             newFileInfo.setMimeType(task.getMimeType());
-            newFileInfo.setIsDir(false);
+            newFileInfo.setIsDir(CommonConstant.N);
             newFileInfo.setParentId(task.getParentId());
             newFileInfo.setWorkspaceId(task.getWorkspaceId());
             newFileInfo.setUserId(task.getUserId());
@@ -361,7 +362,7 @@ public class FileTransferTaskServiceImpl extends ServiceImpl<FileTransferTaskMap
             newFileInfo.setStoragePlatformSettingId(task.getStoragePlatformSettingId());
             newFileInfo.setUploadTime(now);
             newFileInfo.setUpdateTime(now);
-            newFileInfo.setIsDeleted(false);
+            newFileInfo.setIsDeleted(CommonConstant.N);
 
             fileInfoService.save(newFileInfo);
 
@@ -779,7 +780,7 @@ public class FileTransferTaskServiceImpl extends ServiceImpl<FileTransferTaskMap
             fileInfo.setSuffix(task.getSuffix());
             fileInfo.setSize(task.getFileSize());
             fileInfo.setMimeType(task.getMimeType());
-            fileInfo.setIsDir(false);
+            fileInfo.setIsDir(CommonConstant.N);
             fileInfo.setParentId(task.getParentId());
             fileInfo.setWorkspaceId(task.getWorkspaceId());
             fileInfo.setUserId(task.getUserId());
@@ -787,7 +788,7 @@ public class FileTransferTaskServiceImpl extends ServiceImpl<FileTransferTaskMap
             fileInfo.setStoragePlatformSettingId(task.getStoragePlatformSettingId());
             fileInfo.setUploadTime(completeTime);
             fileInfo.setUpdateTime(completeTime);
-            fileInfo.setIsDeleted(false);
+            fileInfo.setIsDeleted(CommonConstant.N);
 
             fileInfoService.save(fileInfo);
 

--- a/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileUserFavoritesServiceImpl.java
+++ b/fs-modules/fs-file/src/main/java/com/xddcodec/fs/file/service/impl/FileUserFavoritesServiceImpl.java
@@ -6,6 +6,7 @@ import com.xddcodec.fs.file.domain.FileInfo;
 import com.xddcodec.fs.file.domain.FileUserFavorites;
 import com.xddcodec.fs.file.mapper.FileUserFavoritesMapper;
 import com.xddcodec.fs.file.service.FileUserFavoritesService;
+import com.xddcodec.fs.framework.common.constant.CommonConstant;
 import com.xddcodec.fs.framework.common.context.WorkspaceContext;
 import com.xddcodec.fs.framework.common.exception.BusinessException;
 import com.xddcodec.fs.framework.common.utils.I18nUtils;
@@ -52,7 +53,7 @@ public class FileUserFavoritesServiceImpl extends ServiceImpl<FileUserFavoritesM
                 QueryWrapper.create()
                         .where(FILE_INFO.ID.in(distinctFileIds))
                         .and(FILE_INFO.WORKSPACE_ID.eq(workspaceId))
-                        .and(FILE_INFO.IS_DELETED.eq(false))
+                        .and(FILE_INFO.IS_DELETED.eq(CommonConstant.N))
         );
         if (fileInfos.isEmpty()) {
             throw new BusinessException(I18nUtils.getMessage("file.favorites.not.found"));
@@ -157,7 +158,7 @@ public class FileUserFavoritesServiceImpl extends ServiceImpl<FileUserFavoritesM
                 .where(FILE_USER_FAVORITES.USER_ID.eq(userId))
                 .and(FILE_USER_FAVORITES.WORKSPACE_ID.eq(workspaceId))
                 .and(FILE_INFO.STORAGE_PLATFORM_SETTING_ID.eq(storagePlatformSettingId))
-                .and(FILE_INFO.IS_DELETED.eq(false))
+                .and(FILE_INFO.IS_DELETED.eq(CommonConstant.N))
         );
     }
 }

--- a/fs-modules/fs-storage/src/main/java/com/xddcodec/fs/storage/domain/StoragePlatform.java
+++ b/fs-modules/fs-storage/src/main/java/com/xddcodec/fs/storage/domain/StoragePlatform.java
@@ -1,9 +1,12 @@
 package com.xddcodec.fs.storage.domain;
 
+import com.mybatisflex.annotation.Column;
 import com.mybatisflex.annotation.Id;
 import com.mybatisflex.annotation.KeyType;
 import com.mybatisflex.annotation.Table;
+import com.xddcodec.fs.framework.orm.handler.JsonStringTypeHandler;
 import lombok.Data;
+import org.apache.ibatis.type.JdbcType;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -40,6 +43,7 @@ public class StoragePlatform implements Serializable {
     /**
      * 存储平台配置描述schema
      */
+    @Column(jdbcType = JdbcType.OTHER, typeHandler = JsonStringTypeHandler.class)
     private String configScheme;
 
     /**

--- a/fs-modules/fs-storage/src/main/java/com/xddcodec/fs/storage/domain/StorageSetting.java
+++ b/fs-modules/fs-storage/src/main/java/com/xddcodec/fs/storage/domain/StorageSetting.java
@@ -3,11 +3,13 @@ package com.xddcodec.fs.storage.domain;
 import com.mybatisflex.annotation.Column;
 import com.mybatisflex.core.keygen.KeyGenerators;
 import com.xddcodec.fs.framework.orm.entity.BaseEntity;
+import com.xddcodec.fs.framework.orm.handler.JsonStringTypeHandler;
 import com.mybatisflex.annotation.Id;
 import com.mybatisflex.annotation.KeyType;
 import com.mybatisflex.annotation.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.apache.ibatis.type.JdbcType;
 
 /**
  * 存储平台配置表
@@ -34,6 +36,7 @@ public class StorageSetting extends BaseEntity {
     /**
      * 配置数据
      */
+    @Column(jdbcType = JdbcType.OTHER, typeHandler = JsonStringTypeHandler.class)
     private String configData;
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <!-- 插件版本 -->
         <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
         <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
-        <maven-compiler-plugin.verison>3.11.0</maven-compiler-plugin.verison>
+        <maven-compiler-plugin.verison>3.13.0</maven-compiler-plugin.verison>
         <flatten-maven-plugin.version>1.2.7</flatten-maven-plugin.version>
     </properties>
 


### PR DESCRIPTION
## 背景

在 PostgreSQL 模式下启动时遇到两类错误：

1. `操作符不存在: smallint = boolean` — 项目历史用 MySQL 的 `tinyint(1)` 模拟布尔，但 PG 严格类型系统下 Java 端 `Boolean` 与 PG `smallint` 不能直接比较。
2. `字段 ... 的类型为 json, 但表达式的类型为 character varying` — MyBatis-Flex 默认把 `String` 走 `setString()`，PG 不会做隐式转换。

## 主要变更

### 1. Boolean → Integer + CommonConstant.Y/N 全链路迁移

仅限数据库列为 `smallint` 的业务布尔字段：
- `FileInfo.isDir` / `FileInfo.isDeleted`
- 三个 VO（`FileVO` / `FileDetailVO` / `FileRecycleVO`）
- `FileQry.isDir`
- 业务方法签名 `generateUniqueName(...Integer isDir,...)`
- 全部 `.eq(true/false)` / `setIsDir(true)` / `getIsDir()` 调用点
- `RecycleBinCleanupTask` 同步

> 说明：`isFavorite` / `isRecents` 仍保持 `Boolean`，**未**在本次改动中触碰。

### 2. PG json 列 TypeHandler

新增 `fs-orm/.../JsonStringTypeHandler`，通过 `ps.setObject(..., Types.OTHER)` 让驱动按列元数据类型识别，规避 PG 的 varchar→json 隐式转换限制。

- 适配字段：`StoragePlatform.configScheme`、`StorageSetting.configData`
- 自描述注册：`@MappedTypes` + `@MappedJdbcTypes`，无需手动注册

## 技术细节

**为什么 Integer + Y/N 而不是 TypeHandler 桥接**

MyBatis-Flex 的 `QueryWrapper.eq(value)` / `UpdateChain.set(field, value)` 把 value 存进 `QueryCondition.value: Object`，绑定 PreparedStatement 时**不**查询实体字段的 `@Column(typeHandler=…)`。TypeHandler 只在 entity ↔ ResultSet/PS 路径生效。无法用 TypeHandler 解决查询/更新路径，因此全链路 Integer 化。

**为什么 JsonStringTypeHandler 用 `Types.OTHER`**

`Types.OTHER` + `String` 让 PostgreSQL JDBC 驱动按列元数据类型（json）解析并校验，比 `Types.VARCHAR`（走 `setString`）安全。

## 测试

在 PG 模式下手动验证：
- 文件列表、回收站、最近使用、收藏夹等查询 → 无 `smallint = boolean` 错误
- 创建存储平台（含 `config_scheme` json 字段）→ 无 `varchar → json` 转换错误

## 文件清单

- `fs-modules/fs-file`: 8 文件（实体、VO、qry、service 4 个 impl、schedule、service 接口）
- `fs-modules/fs-storage`: 2 文件（StoragePlatform、StorageSetting）
- `fs-framework/fs-orm`: 1 新文件（`JsonStringTypeHandler`）
- `pom.xml`: maven-compiler-plugin 3.11.0 → 3.13.0

> 注：前端对应改动（URL 参数 / TypeScript 类型对齐）已在前端仓库 `lengmodkx/free-fs-frontend` 同步提交。

## 兼容性影响

- **API 契约变化**：`FileQry.isDir` 从 `Boolean` 变为 `Integer`，对应前端的 `isDir: number`。后端 schema description 已更新 example 为 `"1"`。
- **数据库**：无 schema 变更。`is_dir` / `is_deleted` 仍是 `smallint`，查询路径与值语义不变。
- **下游消费者**：若有第三方客户端直接调用 `/file/pages?isDir=true`，需改为 `isDir=1`，否则被 Spring 解析为字符串 `"true"` 而非 Integer。

🤖 本 PR 由开发者 `lengmodkx` 编写与提交。